### PR TITLE
Welovesvg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.DS_STORE
 .local/
 .vscode/
 lib/**

--- a/examples/basic/build/index.html
+++ b/examples/basic/build/index.html
@@ -383,7 +383,6 @@ and something different if they don't.";
     <div id="__history"></div>
     <div id="__currentSection"></div>
 </body>
-<script type="text/javascript" src="//cdn.rawgit.com/icons8/bower-webicon/v0.10.7/jquery-webicon.min.js"></script>
 
 </html>
 <script>

--- a/examples/basic/build/index.html
+++ b/examples/basic/build/index.html
@@ -337,8 +337,8 @@ and something different if they don't.";
         </blockquote>
         <p>The inlined function and section above are indented, but that's only because I prefaced them with the Markdown blockquote indicator for clarity. Inlines don't inherently get any special styling, so you can inline things totally seamlessly and
             your players will never know the difference.</p>
-        <p>Finally, you can create links which expand to text in-place, which is commonly used in e.g. <a title="https://twinery.org/2/" target="_blank" href="https://twinery.org/2/">Twine<i class="fa fa-external-link" aria-hidden="true"></i></a> games for
-            artistic effect. You can link to a <a href="#" title="{$InlineExpansionVariable:inline}" data-replace-with="$InlineExpansionVariable" id="_inline-0">variable</a>, or to the return value of a <a href="#" title="{#InlineExpansionFunction:inline}"
+        <p>Finally, you can create links which expand to text in-place, which is commonly used in e.g. <a title="https://twinery.org/2/" target="_blank" href="https://twinery.org/2/">Twine <i class="fa fa-external-link" aria-hidden="true"></i></a> games
+            for artistic effect. You can link to a <a href="#" title="{$InlineExpansionVariable:inline}" data-replace-with="$InlineExpansionVariable" id="_inline-0">variable</a>, or to the return value of a <a href="#" title="{#InlineExpansionFunction:inline}"
                 data-replace-with="#InlineExpansionFunction" id="_inline-1">function</a>, and they'll expand in-place.</p>
         <p><a href="#" title="{@InlineExpansionSection:inline}" data-replace-with="@InlineExpansionSection" id="_inline-2">You can also do this with a section</a></p>
         <p><a href="#" title="{@AboutFormatting}" data-goto-section="AboutFormatting">Can I use Markdown styling?</a></p>

--- a/examples/basic/build/index.html
+++ b/examples/basic/build/index.html
@@ -306,7 +306,7 @@ and something different if they don't.";
             then present one or more choices to the player; each choice takes the story to a different section, and in a different direction.</p>
         <p>In Markdown, you declare the beginning of a new section by enclosing the section name (which must be unique!) in double curly braces. The section you're reading right now is called <code>{{Start}}</code> which is a special section name that indicates
             where the story begins.</p>
-        <p><a title="{@AnotherSection}" href="#" data-goto-section="AnotherSection">Link to another section&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a></p>
+        <p><a title="{@AnotherSection}" href="#" data-goto-section="AnotherSection">Link to another section</a></p>
     </div>
     <div id="AnotherSection" class="section" hidden="true">
         <p>You just clicked a link that took you to another section! You create section links just like any ol' Markdown link, but in place of the URL you put a special <em>macro</em> enclosed in single curly braces. There are three types of macros, each
@@ -318,11 +318,12 @@ and something different if they don't.";
         </ul>
         <p>So if you set the URL to <code>{@Start}</code> you'd have created a link back to the section called <code>Start</code>. If on the other hand you'd put <code>{#Start}</code> you'd have created a link that would call a Javascript function called
             <code>Start</code>.</p>
-        <p><a title="{#FunctionLink}" href="#" data-call-function="FunctionLink">What does it look like when a link calls a Javascript function?&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a><br/><a title="{#VariableLink}" href="#" data-call-function="VariableLink">What happens if I set the link URL to a variable macro?&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a><br/>
+        <p><a title="{#FunctionLink}" href="#" data-call-function="FunctionLink">What does it look like when a link calls a Javascript function?</a><br/><a title="{#VariableLink}" href="#" data-call-function="VariableLink">What happens if I set the link URL to a variable macro?</a><br/>
             <a
-                title="{@InlineMacros}" href="#" data-goto-section="InlineMacros">What else can I use macros for?&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a>
+                title="{@InlineMacros}" href="#" data-goto-section="InlineMacros">What else can I use macros for?</a>
         </p>
-        <p>(P.S. Notice that the first section is still displayed above. That's because we keep track of your play history in a scrollback. You can <a title="{#HideHistory}" href="#" data-call-function="HideHistory">hide the history&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a>            if you like. The UX for this is still going to need some work.)</p>
+        <p>(P.S. Notice that the first section is still displayed above. That's because we keep track of your play history in a scrollback. You can <a title="{#HideHistory}" href="#" data-call-function="HideHistory">hide the history</a> if you like. The
+            UX for this is still going to need some work.)</p>
     </div>
     <div id="InlineMacros" class="section" hidden="true">
         <p>Macros aren't only for links; you can also use them to add dynamic text to your sections.</p>
@@ -337,10 +338,10 @@ and something different if they don't.";
         <p>The inlined function and section above are indented, but that's only because I prefaced them with the Markdown blockquote indicator for clarity. Inlines don't inherently get any special styling, so you can inline things totally seamlessly and
             your players will never know the difference.</p>
         <p>Finally, you can create links which expand to text in-place, which is commonly used in e.g. <a title="https://twinery.org/2/" target="_blank" href="https://twinery.org/2/">Twine&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></a> games
-            for artistic effect. You can link to a <a title="{$InlineExpansionVariable:inline}" href="#" data-replace-with="$InlineExpansionVariable" id="_inline-0">variable&nbsp;<i class="fa fa-exclamation" aria-hidden="true"></i></a>, or to the return
-            value of a <a title="{#InlineExpansionFunction:inline}" href="#" data-replace-with="#InlineExpansionFunction" id="_inline-1">function&nbsp;<i class="fa fa-exclamation" aria-hidden="true"></i></a>, and they'll expand in-place.</p>
-        <p><a title="{@InlineExpansionSection:inline}" href="#" data-replace-with="@InlineExpansionSection" id="_inline-2">You can also do this with a section&nbsp;<i class="fa fa-exclamation" aria-hidden="true"></i></a></p>
-        <p><a title="{@AboutFormatting}" href="#" data-goto-section="AboutFormatting">Can I use Markdown styling?&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a></p>
+            for artistic effect. You can link to a <a title="{$InlineExpansionVariable:inline}" href="#" data-replace-with="$InlineExpansionVariable" id="_inline-0">variable</a>, or to the return value of a <a title="{#InlineExpansionFunction:inline}"
+                href="#" data-replace-with="#InlineExpansionFunction" id="_inline-1">function</a>, and they'll expand in-place.</p>
+        <p><a title="{@InlineExpansionSection:inline}" href="#" data-replace-with="@InlineExpansionSection" id="_inline-2">You can also do this with a section</a></p>
+        <p><a title="{@AboutFormatting}" href="#" data-goto-section="AboutFormatting">Can I use Markdown styling?</a></p>
     </div>
     <div id="InlineSection" class="section" hidden="true">
         <p>This paragraph was written in an entirely different section, but it appears as part of the section you're already reading. This might be useful if you have some boilerplate text that needs to follow the player around from place to place; you could
@@ -349,7 +350,7 @@ and something different if they don't.";
     <div id="InlineExpansionSection" class="section" hidden="true">
         <p>Sections are kind of special though, in that they don't actually appear inline <em>per se</em>, because they're block-level elements (i.e. their own paragraphs) which means they'll put a paragraph break where they appear. They still replace their
             :inline macro link though, just like with variables and functions. When inline-expanding a section, you can still have paragraph breaks, <em>additional</em> <strong>formatting</strong>, and so on. And you can even inline sections which themselves
-            contain <a title="{#RaiseAlert}" href="#" data-call-function="RaiseAlert">macros&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a>!</p>
+            contain <a title="{#RaiseAlert}" href="#" data-call-function="RaiseAlert">macros</a>!</p>
     </div>
     <div id="AboutFormatting" class="section" hidden="true">
         <p>Story text is written in Markdown, which means we have access to <em>all kinds</em> of <strong>formatting</strong>, including:</p>
@@ -358,12 +359,12 @@ and something different if they don't.";
         <ul>
             <li>Unordered lists (like this one)</li>
             <li>Ordered lists (1, 2, 3, 4...)</li>
-            <li>Links can also <a title="{#RaiseAlert}" href="#" data-call-function="RaiseAlert"><em>contain</em> <strong>formatting</strong>&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a></li>
+            <li>Links can also <a title="{#RaiseAlert}" href="#" data-call-function="RaiseAlert"><em>contain</em> <strong>formatting</strong></a></li>
         </ul>
         <p>Basically, anything Markdown can do, you can do in your story text! You can even inline <span style="color:#ff0000">raw HTML</span> which means you could do video embeds, HTML5 canvas, and all kinds of other fancy stuff.</p>
         <p>And of course, because fractive games are ultimately HTML in the end, you can create your own HTML template with whatever layout you want, and style it with CSS. For example, you could surround your game with a header and footer, or create a sidebar
             which (along with some custom Javascript) tracks your player's inventory and stats as they move through the story.</p>
-        <p><a title="{@LongStories}" href="#" data-goto-section="LongStories">How does fractive handle long/complicated stories?&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a></p>
+        <p><a title="{@LongStories}" href="#" data-goto-section="LongStories">How does fractive handle long/complicated stories?</a></p>
     </div>
     <div id="LongStories" class="section" hidden="true">
         <p>Fractive's main goal is to be the best tool for writing complex, dynamic hypertext fiction that has lots of branches and genuinely consequential choices. What you're reading right now is produced by a <em>very</em> eary version of the tool, so
@@ -374,9 +375,9 @@ and something different if they don't.";
         <p>In the future I'll be exploring additional tools and visualizations to help authors understand, trace, and debug the complexity of large, deeply-branching narratives. Those tools and visualizers will likely be the most experimental, and pivotal,
             aspects of fractive's development.</p>
         <p>Anything you'd like to review?</p>
-        <p><a title="{#FunctionLink}" href="#" data-call-function="FunctionLink">What does it look like when a link calls a Javascript function?&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a><br/><a title="{#VariableLink}" href="#" data-call-function="VariableLink">What happens if I set the link URL to a variable macro?&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a><br/>
+        <p><a title="{#FunctionLink}" href="#" data-call-function="FunctionLink">What does it look like when a link calls a Javascript function?</a><br/><a title="{#VariableLink}" href="#" data-call-function="VariableLink">What happens if I set the link URL to a variable macro?</a><br/>
             <a
-                title="{@InlineMacros}" href="#" data-goto-section="InlineMacros">What else can I use macros for?&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a><br/><a title="{@AboutFormatting}" href="#" data-goto-section="AboutFormatting">Can I use Markdown styling?&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a></p>
+                title="{@InlineMacros}" href="#" data-goto-section="InlineMacros">What else can I use macros for?</a><br/><a title="{@AboutFormatting}" href="#" data-goto-section="AboutFormatting">Can I use Markdown styling?</a></p>
     </div>
 
     <div id="__history"></div>

--- a/examples/basic/build/index.html
+++ b/examples/basic/build/index.html
@@ -306,7 +306,7 @@ and something different if they don't.";
             then present one or more choices to the player; each choice takes the story to a different section, and in a different direction.</p>
         <p>In Markdown, you declare the beginning of a new section by enclosing the section name (which must be unique!) in double curly braces. The section you're reading right now is called <code>{{Start}}</code> which is a special section name that indicates
             where the story begins.</p>
-        <p><a href="#" title="{@AnotherSection}" data-goto-section="AnotherSection">Link to another section</a></p>
+        <p><a title="{@AnotherSection}" href="#" data-goto-section="AnotherSection">Link to another section&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a></p>
     </div>
     <div id="AnotherSection" class="section" hidden="true">
         <p>You just clicked a link that took you to another section! You create section links just like any ol' Markdown link, but in place of the URL you put a special <em>macro</em> enclosed in single curly braces. There are three types of macros, each
@@ -318,12 +318,11 @@ and something different if they don't.";
         </ul>
         <p>So if you set the URL to <code>{@Start}</code> you'd have created a link back to the section called <code>Start</code>. If on the other hand you'd put <code>{#Start}</code> you'd have created a link that would call a Javascript function called
             <code>Start</code>.</p>
-        <p><a href="#" title="{#FunctionLink}" data-call-function="FunctionLink">What does it look like when a link calls a Javascript function?</a><br/><a href="#" title="{#VariableLink}" data-call-function="VariableLink">What happens if I set the link URL to a variable macro?</a><br/>
+        <p><a title="{#FunctionLink}" href="#" data-call-function="FunctionLink">What does it look like when a link calls a Javascript function?&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a><br/><a title="{#VariableLink}" href="#" data-call-function="VariableLink">What happens if I set the link URL to a variable macro?&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a><br/>
             <a
-                href="#" title="{@InlineMacros}" data-goto-section="InlineMacros">What else can I use macros for?</a>
+                title="{@InlineMacros}" href="#" data-goto-section="InlineMacros">What else can I use macros for?&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a>
         </p>
-        <p>(P.S. Notice that the first section is still displayed above. That's because we keep track of your play history in a scrollback. You can <a href="#" title="{#HideHistory}" data-call-function="HideHistory">hide the history</a> if you like. The
-            UX for this is still going to need some work.)</p>
+        <p>(P.S. Notice that the first section is still displayed above. That's because we keep track of your play history in a scrollback. You can <a title="{#HideHistory}" href="#" data-call-function="HideHistory">hide the history&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a>            if you like. The UX for this is still going to need some work.)</p>
     </div>
     <div id="InlineMacros" class="section" hidden="true">
         <p>Macros aren't only for links; you can also use them to add dynamic text to your sections.</p>
@@ -337,11 +336,11 @@ and something different if they don't.";
         </blockquote>
         <p>The inlined function and section above are indented, but that's only because I prefaced them with the Markdown blockquote indicator for clarity. Inlines don't inherently get any special styling, so you can inline things totally seamlessly and
             your players will never know the difference.</p>
-        <p>Finally, you can create links which expand to text in-place, which is commonly used in e.g. <a title="https://twinery.org/2/" target="_blank" href="https://twinery.org/2/">Twine <i class="fa fa-external-link" aria-hidden="true"></i></a> games
-            for artistic effect. You can link to a <a href="#" title="{$InlineExpansionVariable:inline}" data-replace-with="$InlineExpansionVariable" id="_inline-0">variable</a>, or to the return value of a <a href="#" title="{#InlineExpansionFunction:inline}"
-                data-replace-with="#InlineExpansionFunction" id="_inline-1">function</a>, and they'll expand in-place.</p>
-        <p><a href="#" title="{@InlineExpansionSection:inline}" data-replace-with="@InlineExpansionSection" id="_inline-2">You can also do this with a section</a></p>
-        <p><a href="#" title="{@AboutFormatting}" data-goto-section="AboutFormatting">Can I use Markdown styling?</a></p>
+        <p>Finally, you can create links which expand to text in-place, which is commonly used in e.g. <a title="https://twinery.org/2/" target="_blank" href="https://twinery.org/2/">Twine&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></a> games
+            for artistic effect. You can link to a <a title="{$InlineExpansionVariable:inline}" href="#" data-replace-with="$InlineExpansionVariable" id="_inline-0">variable&nbsp;<i class="fa fa-exclamation" aria-hidden="true"></i></a>, or to the return
+            value of a <a title="{#InlineExpansionFunction:inline}" href="#" data-replace-with="#InlineExpansionFunction" id="_inline-1">function&nbsp;<i class="fa fa-exclamation" aria-hidden="true"></i></a>, and they'll expand in-place.</p>
+        <p><a title="{@InlineExpansionSection:inline}" href="#" data-replace-with="@InlineExpansionSection" id="_inline-2">You can also do this with a section&nbsp;<i class="fa fa-exclamation" aria-hidden="true"></i></a></p>
+        <p><a title="{@AboutFormatting}" href="#" data-goto-section="AboutFormatting">Can I use Markdown styling?&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a></p>
     </div>
     <div id="InlineSection" class="section" hidden="true">
         <p>This paragraph was written in an entirely different section, but it appears as part of the section you're already reading. This might be useful if you have some boilerplate text that needs to follow the player around from place to place; you could
@@ -350,7 +349,7 @@ and something different if they don't.";
     <div id="InlineExpansionSection" class="section" hidden="true">
         <p>Sections are kind of special though, in that they don't actually appear inline <em>per se</em>, because they're block-level elements (i.e. their own paragraphs) which means they'll put a paragraph break where they appear. They still replace their
             :inline macro link though, just like with variables and functions. When inline-expanding a section, you can still have paragraph breaks, <em>additional</em> <strong>formatting</strong>, and so on. And you can even inline sections which themselves
-            contain <a href="#" title="{#RaiseAlert}" data-call-function="RaiseAlert">macros</a>!</p>
+            contain <a title="{#RaiseAlert}" href="#" data-call-function="RaiseAlert">macros&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a>!</p>
     </div>
     <div id="AboutFormatting" class="section" hidden="true">
         <p>Story text is written in Markdown, which means we have access to <em>all kinds</em> of <strong>formatting</strong>, including:</p>
@@ -359,12 +358,12 @@ and something different if they don't.";
         <ul>
             <li>Unordered lists (like this one)</li>
             <li>Ordered lists (1, 2, 3, 4...)</li>
-            <li>Links can also <a href="#" title="{#RaiseAlert}" data-call-function="RaiseAlert"><em>contain</em> <strong>formatting</strong></a></li>
+            <li>Links can also <a title="{#RaiseAlert}" href="#" data-call-function="RaiseAlert"><em>contain</em> <strong>formatting</strong>&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a></li>
         </ul>
         <p>Basically, anything Markdown can do, you can do in your story text! You can even inline <span style="color:#ff0000">raw HTML</span> which means you could do video embeds, HTML5 canvas, and all kinds of other fancy stuff.</p>
         <p>And of course, because fractive games are ultimately HTML in the end, you can create your own HTML template with whatever layout you want, and style it with CSS. For example, you could surround your game with a header and footer, or create a sidebar
             which (along with some custom Javascript) tracks your player's inventory and stats as they move through the story.</p>
-        <p><a href="#" title="{@LongStories}" data-goto-section="LongStories">How does fractive handle long/complicated stories?</a></p>
+        <p><a title="{@LongStories}" href="#" data-goto-section="LongStories">How does fractive handle long/complicated stories?&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a></p>
     </div>
     <div id="LongStories" class="section" hidden="true">
         <p>Fractive's main goal is to be the best tool for writing complex, dynamic hypertext fiction that has lots of branches and genuinely consequential choices. What you're reading right now is produced by a <em>very</em> eary version of the tool, so
@@ -375,9 +374,9 @@ and something different if they don't.";
         <p>In the future I'll be exploring additional tools and visualizations to help authors understand, trace, and debug the complexity of large, deeply-branching narratives. Those tools and visualizers will likely be the most experimental, and pivotal,
             aspects of fractive's development.</p>
         <p>Anything you'd like to review?</p>
-        <p><a href="#" title="{#FunctionLink}" data-call-function="FunctionLink">What does it look like when a link calls a Javascript function?</a><br/><a href="#" title="{#VariableLink}" data-call-function="VariableLink">What happens if I set the link URL to a variable macro?</a><br/>
+        <p><a title="{#FunctionLink}" href="#" data-call-function="FunctionLink">What does it look like when a link calls a Javascript function?&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a><br/><a title="{#VariableLink}" href="#" data-call-function="VariableLink">What happens if I set the link URL to a variable macro?&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a><br/>
             <a
-                href="#" title="{@InlineMacros}" data-goto-section="InlineMacros">What else can I use macros for?</a><br/><a href="#" title="{@AboutFormatting}" data-goto-section="AboutFormatting">Can I use Markdown styling?</a></p>
+                title="{@InlineMacros}" href="#" data-goto-section="InlineMacros">What else can I use macros for?&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a><br/><a title="{@AboutFormatting}" href="#" data-goto-section="AboutFormatting">Can I use Markdown styling?&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a></p>
     </div>
 
     <div id="__history"></div>

--- a/examples/basic/build/index.html
+++ b/examples/basic/build/index.html
@@ -2,6 +2,7 @@
 
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet"></link>
     <style>
         #__history {
             color: silver !important;
@@ -336,9 +337,10 @@ and something different if they don't.";
         </blockquote>
         <p>The inlined function and section above are indented, but that's only because I prefaced them with the Markdown blockquote indicator for clarity. Inlines don't inherently get any special styling, so you can inline things totally seamlessly and
             your players will never know the difference.</p>
-        <p>Finally, you can create links which expand to text in-place, which is commonly used in e.g. <a href="https://twinery.org/2/">Twine</a> games for artistic effect. You can link to a <a href="#" id="_inline-0" title="{$InlineExpansionVariable:inline}"
-                data-replace-with="$InlineExpansionVariable">variable</a>, or to the return value of a <a href="#" id="_inline-1" title="{#InlineExpansionFunction:inline}" data-replace-with="#InlineExpansionFunction">function</a>, and they'll expand in-place.</p>
-        <p><a href="#" id="_inline-2" title="{@InlineExpansionSection:inline}" data-replace-with="@InlineExpansionSection">You can also do this with a section</a></p>
+        <p>Finally, you can create links which expand to text in-place, which is commonly used in e.g. <a title="https://twinery.org/2/" target="_blank" href="https://twinery.org/2/">Twine<i class="fa fa-external-link" aria-hidden="true"></i></a> games for
+            artistic effect. You can link to a <a href="#" title="{$InlineExpansionVariable:inline}" data-replace-with="$InlineExpansionVariable" id="_inline-0">variable</a>, or to the return value of a <a href="#" title="{#InlineExpansionFunction:inline}"
+                data-replace-with="#InlineExpansionFunction" id="_inline-1">function</a>, and they'll expand in-place.</p>
+        <p><a href="#" title="{@InlineExpansionSection:inline}" data-replace-with="@InlineExpansionSection" id="_inline-2">You can also do this with a section</a></p>
         <p><a href="#" title="{@AboutFormatting}" data-goto-section="AboutFormatting">Can I use Markdown styling?</a></p>
     </div>
     <div id="InlineSection" class="section" hidden="true">
@@ -381,6 +383,7 @@ and something different if they don't.";
     <div id="__history"></div>
     <div id="__currentSection"></div>
 </body>
+<script type="text/javascript" src="//cdn.rawgit.com/icons8/bower-webicon/v0.10.7/jquery-webicon.min.js"></script>
 
 </html>
 <script>

--- a/examples/basic/fractive.json
+++ b/examples/basic/fractive.json
@@ -1,5 +1,6 @@
 {
 	"title": "basic",
 	"template": "../../templates/basic.html",
-	"linkTooltips": true
+	"linkTooltips": true,
+	"externalLinkHTML": " <i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>"
 }

--- a/examples/basic/fractive.json
+++ b/examples/basic/fractive.json
@@ -5,6 +5,7 @@
 	"linkTags": {
 		"external": " <i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>",
 		"inline": "<i class=\"fa fa-exclamation\" aria-hidden=\"true\"></i>",
-		"section": "<i class=\"fa fa-arrow-right\" aria-hidden=\"true\"></i>"
+		"section": "<i class=\"fa fa-arrow-right\" aria-hidden=\"true\"></i>",
+		"function": "<i class=\"fa fa-bolt\" aria-hidden=\"true\"></i>"
 	}
 }

--- a/examples/basic/fractive.json
+++ b/examples/basic/fractive.json
@@ -3,9 +3,9 @@
 	"template": "../../templates/basic.html",
 	"linkTooltips": true,
 	"linkTags": {
-		"external": " <i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>",
-		"inline": "<i class=\"fa fa-exclamation\" aria-hidden=\"true\"></i>",
-		"section": "<i class=\"fa fa-arrow-right\" aria-hidden=\"true\"></i>",
-		"function": "<i class=\"fa fa-bolt\" aria-hidden=\"true\"></i>"
+		"external": "&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>",
+		"inline": "&nbsp;<i class=\"fa fa-exclamation\" aria-hidden=\"true\"></i>",
+		"section": "&nbsp;<i class=\"fa fa-arrow-right\" aria-hidden=\"true\"></i>",
+		"function": "&nbsp;<i class=\"fa fa-bolt\" aria-hidden=\"true\"></i>"
 	}
 }

--- a/examples/basic/fractive.json
+++ b/examples/basic/fractive.json
@@ -2,5 +2,9 @@
 	"title": "basic",
 	"template": "../../templates/basic.html",
 	"linkTooltips": true,
-	"externalLinkHTML": " <i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>"
+	"linkTags": {
+		"external": " <i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>",
+		"inline": "<i class=\"fa fa-exclamation\" aria-hidden=\"true\"></i>",
+		"section": "<i class=\"fa fa-arrow-right\" aria-hidden=\"true\"></i>"
+	}
 }

--- a/examples/basic/fractive.json
+++ b/examples/basic/fractive.json
@@ -3,9 +3,6 @@
 	"template": "../../templates/basic.html",
 	"linkTooltips": true,
 	"linkTags": {
-		"external": "&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>",
-		"inline": "&nbsp;<i class=\"fa fa-exclamation\" aria-hidden=\"true\"></i>",
-		"section": "&nbsp;<i class=\"fa fa-arrow-right\" aria-hidden=\"true\"></i>",
-		"function": "&nbsp;<i class=\"fa fa-bolt\" aria-hidden=\"true\"></i>"
+		"external": "&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>"
 	}
 }

--- a/examples/macros/build/index.html
+++ b/examples/macros/build/index.html
@@ -2,6 +2,7 @@
 
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet"></link>
     <style>
         #__history {
             color: silver !important;
@@ -303,7 +304,10 @@
         <p>Aliases can enable <span style='color:#ff8888'>clean inline styling</span>!</p>
         <h1>Links</h1>
         <p><a href="#" title="{@TestSection}" data-goto-section="TestSection">Link to a section</a><br/><a href="#" title="{#LinkedFunction}" data-call-function="LinkedFunction">Link to a function</a></p>
-        <p><a href="#">Link with a section in the label: <span data-expand-macro="@TestSection"></span></a><br/><a href="#">Link with a function in the label: <span data-expand-macro="#TestFunction"></span></a><br/><a href="#">Link with a variable in the label: <span data-expand-macro="$TestVariable"></span></a></p>
+        <p><a title="#" target="_blank" href="#">Link with a section in the label: <span data-expand-macro="@TestSection"></span><i class="fa fa-external-link" aria-hidden="true"></i></a><br/><a title="#" target="_blank" href="#">Link with a function in the label: <span data-expand-macro="#TestFunction"></span><i class="fa fa-external-link" aria-hidden="true"></i></a><br/>
+            <a
+                title="#" target="_blank" href="#">Link with a variable in the label: <span data-expand-macro="$TestVariable"></span><i class="fa fa-external-link" aria-hidden="true"></i></a>
+        </p>
         <h1>Images</h1>
         <p><img src="assets/avatar.png" alt="Image with a direct url" title="Image with a direct url"><br/><img data-image-source-macro="#ImageFunction" src="#" alt="Image with a function url" title="Image with a function url"><br/><img data-image-source-macro="$ImageVariable"
                 src="#" alt="Image with a variable url" title="Image with a variable url"></p>
@@ -479,6 +483,7 @@
     <div id="__history"></div>
     <div id="__currentSection"></div>
 </body>
+<script type="text/javascript" src="//cdn.rawgit.com/icons8/bower-webicon/v0.10.7/jquery-webicon.min.js"></script>
 
 </html>
 <script>

--- a/examples/macros/build/index.html
+++ b/examples/macros/build/index.html
@@ -303,7 +303,7 @@
         <p>Aliases are awesome!</p>
         <p>Aliases can enable <span style='color:#ff8888'>clean inline styling</span>!</p>
         <h1>Links</h1>
-        <p><a href="#" title="{@TestSection}" data-goto-section="TestSection">Link to a section</a><br/><a href="#" title="{#LinkedFunction}" data-call-function="LinkedFunction">Link to a function</a></p>
+        <p><a title="{@TestSection}" href="#" data-goto-section="TestSection">Link to a section <i class="fa fa-arrow-right" aria-hidden="true"></i></a><br/><a title="{#LinkedFunction}" href="#" data-call-function="LinkedFunction">Link to a function <i class="fa fa-bolt" aria-hidden="true"></i></a></p>
         <p><a title="#" target="_blank" href="#">Link with a section in the label: <span data-expand-macro="@TestSection"></span> <i class="fa fa-external-link" aria-hidden="true"></i></a><br/><a title="#" target="_blank" href="#">Link with a function in the label: <span data-expand-macro="#TestFunction"></span> <i class="fa fa-external-link" aria-hidden="true"></i></a><br/>
             <a
                 title="#" target="_blank" href="#">Link with a variable in the label: <span data-expand-macro="$TestVariable"></span> <i class="fa fa-external-link" aria-hidden="true"></i></a>

--- a/examples/macros/build/index.html
+++ b/examples/macros/build/index.html
@@ -303,10 +303,10 @@
         <p>Aliases are awesome!</p>
         <p>Aliases can enable <span style='color:#ff8888'>clean inline styling</span>!</p>
         <h1>Links</h1>
-        <p><a title="{@TestSection}" href="#" data-goto-section="TestSection">Link to a section <i class="fa fa-arrow-right" aria-hidden="true"></i></a><br/><a title="{#LinkedFunction}" href="#" data-call-function="LinkedFunction">Link to a function <i class="fa fa-bolt" aria-hidden="true"></i></a></p>
-        <p><a title="#" target="_blank" href="#">Link with a section in the label: <span data-expand-macro="@TestSection"></span> <i class="fa fa-external-link" aria-hidden="true"></i></a><br/><a title="#" target="_blank" href="#">Link with a function in the label: <span data-expand-macro="#TestFunction"></span> <i class="fa fa-external-link" aria-hidden="true"></i></a><br/>
+        <p><a title="{@TestSection}" href="#" data-goto-section="TestSection">Link to a section</a><br/><a title="{#LinkedFunction}" href="#" data-call-function="LinkedFunction">Link to a function</a></p>
+        <p><a title="#" target="_blank" href="#">Link with a section in the label: <span data-expand-macro="@TestSection"></span>&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></a><br/><a title="#" target="_blank" href="#">Link with a function in the label: <span data-expand-macro="#TestFunction"></span>&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></a><br/>
             <a
-                title="#" target="_blank" href="#">Link with a variable in the label: <span data-expand-macro="$TestVariable"></span> <i class="fa fa-external-link" aria-hidden="true"></i></a>
+                title="#" target="_blank" href="#">Link with a variable in the label: <span data-expand-macro="$TestVariable"></span>&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></a>
         </p>
         <h1>Images</h1>
         <p><img src="assets/avatar.png" alt="Image with a direct url" title="Image with a direct url"><br/><img data-image-source-macro="#ImageFunction" src="#" alt="Image with a function url" title="Image with a function url"><br/><img data-image-source-macro="$ImageVariable"

--- a/examples/macros/build/index.html
+++ b/examples/macros/build/index.html
@@ -483,7 +483,6 @@
     <div id="__history"></div>
     <div id="__currentSection"></div>
 </body>
-<script type="text/javascript" src="//cdn.rawgit.com/icons8/bower-webicon/v0.10.7/jquery-webicon.min.js"></script>
 
 </html>
 <script>

--- a/examples/macros/build/index.html
+++ b/examples/macros/build/index.html
@@ -304,9 +304,9 @@
         <p>Aliases can enable <span style='color:#ff8888'>clean inline styling</span>!</p>
         <h1>Links</h1>
         <p><a href="#" title="{@TestSection}" data-goto-section="TestSection">Link to a section</a><br/><a href="#" title="{#LinkedFunction}" data-call-function="LinkedFunction">Link to a function</a></p>
-        <p><a title="#" target="_blank" href="#">Link with a section in the label: <span data-expand-macro="@TestSection"></span><i class="fa fa-external-link" aria-hidden="true"></i></a><br/><a title="#" target="_blank" href="#">Link with a function in the label: <span data-expand-macro="#TestFunction"></span><i class="fa fa-external-link" aria-hidden="true"></i></a><br/>
+        <p><a title="#" target="_blank" href="#">Link with a section in the label: <span data-expand-macro="@TestSection"></span> <i class="fa fa-external-link" aria-hidden="true"></i></a><br/><a title="#" target="_blank" href="#">Link with a function in the label: <span data-expand-macro="#TestFunction"></span> <i class="fa fa-external-link" aria-hidden="true"></i></a><br/>
             <a
-                title="#" target="_blank" href="#">Link with a variable in the label: <span data-expand-macro="$TestVariable"></span><i class="fa fa-external-link" aria-hidden="true"></i></a>
+                title="#" target="_blank" href="#">Link with a variable in the label: <span data-expand-macro="$TestVariable"></span> <i class="fa fa-external-link" aria-hidden="true"></i></a>
         </p>
         <h1>Images</h1>
         <p><img src="assets/avatar.png" alt="Image with a direct url" title="Image with a direct url"><br/><img data-image-source-macro="#ImageFunction" src="#" alt="Image with a function url" title="Image with a function url"><br/><img data-image-source-macro="$ImageVariable"

--- a/examples/macros/fractive.json
+++ b/examples/macros/fractive.json
@@ -6,5 +6,9 @@
 	],
 	"template": "../../templates/basic.html",
 	"linkTooltips": true,
-	"externalLinkHTML": " <i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>"
+	"linkTags": {
+		"external": " <i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>",
+		"inline": "<i class=\"fa fa-exclamation\" aria-hidden=\"true\"></i>",
+		"section": "<i class=\"fa fa-arrow-right\" aria-hidden=\"true\"></i>"
+	}
 }

--- a/examples/macros/fractive.json
+++ b/examples/macros/fractive.json
@@ -7,9 +7,6 @@
 	"template": "../../templates/basic.html",
 	"linkTooltips": true,
 	"linkTags": {
-		"external": " <i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>",
-		"inline": " <i class=\"fa fa-exclamation\" aria-hidden=\"true\"></i>",
-		"section": " <i class=\"fa fa-arrow-right\" aria-hidden=\"true\"></i>",
-		"function": " <i class=\"fa fa-bolt\" aria-hidden=\"true\"></i>"
+		"external": "&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>"
 	}
 }

--- a/examples/macros/fractive.json
+++ b/examples/macros/fractive.json
@@ -5,5 +5,6 @@
 		{ "alias": "red", "replaceWith": "<span style='color:#ff8888'>", "end": "</span>" }
 	],
 	"template": "../../templates/basic.html",
-	"linkTooltips": true
+	"linkTooltips": true,
+	"externalLinkHTML": " <i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>"
 }

--- a/examples/macros/fractive.json
+++ b/examples/macros/fractive.json
@@ -8,7 +8,8 @@
 	"linkTooltips": true,
 	"linkTags": {
 		"external": " <i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>",
-		"inline": "<i class=\"fa fa-exclamation\" aria-hidden=\"true\"></i>",
-		"section": "<i class=\"fa fa-arrow-right\" aria-hidden=\"true\"></i>"
+		"inline": " <i class=\"fa fa-exclamation\" aria-hidden=\"true\"></i>",
+		"section": " <i class=\"fa fa-arrow-right\" aria-hidden=\"true\"></i>",
+		"function": " <i class=\"fa fa-bolt\" aria-hidden=\"true\"></i>"
 	}
 }

--- a/examples/tags/build/index.html
+++ b/examples/tags/build/index.html
@@ -1,0 +1,329 @@
+<html>
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet"></link>
+    <style>
+        #__history {
+            color: silver !important;
+            position: absolute;
+            left: 2%;
+            width: 47%;
+            max-height: 100%;
+            overflow: scroll;
+        }
+
+        #__history .__inlineMacro {
+            animation: none;
+            color: silver;
+        }
+
+        #__currentSection {
+            color: black;
+            animation: 2s textFadeIn;
+            position: absolute;
+            left: 51%;
+            width: 47%;
+            max-height: 100%;
+            overflow: scroll;
+        }
+
+        .__disabledLink {
+            color: silver;
+            text-decoration: underline;
+        }
+
+        .__inlineMacro {
+            animation: 2s inlineMacroFadeIn;
+            color: blue;
+        }
+
+        @keyframes textFadeIn {
+            from {
+                color: white;
+            }
+            to {
+                color: black;
+            }
+        }
+
+        @keyframes inlineMacroFadeIn {
+            from {
+                color: white;
+            }
+            to {
+                color: blue;
+            }
+        }
+    </style>
+    <script>
+        var exports = {};
+        "use strict";
+        Object.defineProperty(exports, "__esModule", {
+            value: true
+        });
+        var Core;
+        (function(Core) {
+            function EnableInlineMacros(root, tf) {
+                if (tf === void 0) {
+                    tf = true;
+                }
+                if (tf && root.id.search("_inline\-") > -1) {
+                    root.id = root.id.substring(1);
+                } else if (!tf && root.id.search("inline\-") > -1) {
+                    root.id = "_" + root.id;
+                }
+                for (var i = 0; i < root.children.length; i++) {
+                    EnableInlineMacros(root.children[i], tf);
+                }
+            }
+
+            function ExpandMacro(macro) {
+                switch (macro[0]) {
+                    case '@':
+                        {
+                            var sectionName = macro.substring(1);
+                            if (!document.getElementById(sectionName)) {
+                                return "{section \"" + sectionName + "\" is not declared}";
+                            } else {
+                                return ExpandSection(macro.substring(1)).innerHTML;
+                            }
+                        }
+                    case '#':
+                        {
+                            var targetObject = null;
+                            var tokens = macro.substring(1).split('.');
+                            for (var i = 0; i < tokens.length; i++) {
+                                if (i === 0) {
+                                    targetObject = window[tokens[0]];
+                                } else {
+                                    targetObject = targetObject[tokens[i]];
+                                }
+                            }
+                            if (targetObject === undefined) {
+                                return "{function \"" + macro.substring(1) + "\" is not declared}";
+                            } else {
+                                return targetObject().toString();
+                            }
+                        }
+                    case '$':
+                        {
+                            var targetObject = null;
+                            var tokens = macro.substring(1).split('.');
+                            for (var i = 0; i < tokens.length; i++) {
+                                if (i === 0) {
+                                    targetObject = window[tokens[0]];
+                                } else {
+                                    targetObject = targetObject[tokens[i]];
+                                }
+                            }
+                            if (targetObject === undefined) {
+                                return "{variable \"" + macro.substring(1) + "\" is not declared}";
+                            } else {
+                                return targetObject.toString();
+                            }
+                        }
+                    default:
+                        {
+                            return "{unknown metacharacter in macro \"" + macro + "\"";
+                        }
+                }
+            }
+            Core.ExpandMacro = ExpandMacro;
+
+            function ExpandSection(id) {
+                var source = document.getElementById(id);
+                if (source === null) {
+                    console.log("Section " + id + " doesn't exist");
+                    return null;
+                }
+                var sectionInstance = source.cloneNode(true);
+                sectionInstance.removeAttribute("hidden");
+                var scan = function(element) {
+                    for (var i = 0; i < element.attributes.length; i++) {
+                        var expanded = false;
+                        switch (element.attributes[i].name) {
+                            case "data-expand-macro":
+                                {
+                                    if (element.parentElement) {
+                                        var newElement = document.createElement("span");
+                                        newElement.innerHTML = ExpandMacro(element.attributes[i].value);
+                                        element.parentElement.replaceChild(newElement, element);
+                                        expanded = true;
+                                    }
+                                    break;
+                                }
+                            case "data-image-source-macro":
+                                {
+                                    var source_1 = ExpandMacro(element.attributes[i].value);
+                                    console.log("Expanding " + element.tagName + " with src attribute " + element.attributes[i].value + " to \"" + source_1 + "\"");
+                                    element.setAttribute("src", ExpandMacro(element.attributes[i].value));
+                                    expanded = true;
+                                }
+                        }
+                        if (expanded) {
+                            break;
+                        }
+                    }
+                    if (element.hasChildNodes) {
+                        for (var i = 0; i < element.children.length; i++) {
+                            scan(element.children[i]);
+                        }
+                    }
+                };
+                scan(sectionInstance);
+                return sectionInstance;
+            }
+
+            function GotoSection(id) {
+                var history = document.getElementById("__history");
+                var currentSection = document.getElementById("__currentSection");
+                var links = currentSection.getElementsByTagName("a");
+                for (var i = 0; i < links.length;) {
+                    var contents = links[i].outerHTML.substring(links[i].outerHTML.indexOf(">") + 1, links[i].outerHTML.indexOf("</a>"));
+                    links[i].outerHTML = "<span class=\"__disabledLink\">" + contents + "</span>";
+                }
+                history.innerHTML += currentSection.innerHTML;
+                history.scrollTop = history.scrollHeight;
+                var clone = ExpandSection(id);
+                EnableInlineMacros(clone, true);
+                RegisterLinks(clone);
+                clone.scrollTop = 0;
+                clone.id = "__currentSection";
+                currentSection.parentElement.replaceChild(clone, currentSection);
+            }
+            Core.GotoSection = GotoSection;
+
+            function RegisterLinks(element) {
+                if (element.tagName == "A") {
+                    var _loop_1 = function(i) {
+                        switch (element.attributes[i].name) {
+                            case "data-goto-section":
+                                {
+                                    element.addEventListener("click", function() {
+                                        Core.GotoSection(element.attributes[i].value);
+                                    });
+                                    break;
+                                }
+                            case "data-call-function":
+                                {
+                                    element.addEventListener("click", window[element.attributes[i].value]);
+                                    break;
+                                }
+                            case "data-replace-with":
+                                {
+                                    element.addEventListener("click", function() {
+                                        Core.ReplaceActiveElement(element.id, ExpandMacro(element.attributes[i].value));
+                                    });
+                                    break;
+                                }
+                        }
+                    };
+                    for (var i = 0; i < element.attributes.length; i++) {
+                        _loop_1(i);
+                    }
+                }
+                if (element.hasChildNodes) {
+                    for (var i = 0; i < element.children.length; i++) {
+                        RegisterLinks(element.children[i]);
+                    }
+                }
+            }
+            Core.RegisterLinks = RegisterLinks;
+
+            function ReplaceActiveElement(id, html) {
+                for (var element = document.getElementById(id); element; element = document.getElementById(id)) {
+                    if (!element) {
+                        continue;
+                    }
+                    var bIsActive = false;
+                    for (var parent_1 = element.parentElement; parent_1; parent_1 = parent_1.parentElement) {
+                        if (parent_1.id === "__currentSection") {
+                            bIsActive = true;
+                            break;
+                        }
+                    }
+                    if (bIsActive) {
+                        var replacement = document.createElement("span");
+                        replacement.className = "__inlineMacro";
+                        replacement.innerHTML = html;
+                        EnableInlineMacros(replacement, true);
+                        RegisterLinks(replacement);
+                        element.parentNode.replaceChild(replacement, element);
+                        break;
+                    }
+                }
+            }
+            Core.ReplaceActiveElement = ReplaceActiveElement;
+
+            function ShowHistory(tf) {
+                var history = document.getElementById("__history");
+                history.hidden = !tf;
+            }
+            Core.ShowHistory = ShowHistory;
+        })(Core = exports.Core || (exports.Core = {}));
+        //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiQ29yZS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uL3NyYy9Db3JlLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7O0FBc0JBLElBQWlCLElBQUksQ0F1UnBCO0FBdlJELFdBQWlCLElBQUk7SUFTcEIsNEJBQTRCLElBQWMsRUFBRSxFQUFtQjtRQUFuQixtQkFBQSxFQUFBLFNBQW1CO1FBSTlELEVBQUUsQ0FBQSxDQUFDLEVBQUUsSUFBSSxJQUFJLENBQUMsRUFBRSxDQUFDLE1BQU0sQ0FBQyxXQUFXLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7WUFBQyxJQUFJLENBQUMsRUFBRSxHQUFHLElBQUksQ0FBQyxFQUFFLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQUMsQ0FBQztRQUM5RSxJQUFJLENBQUMsRUFBRSxDQUFBLENBQUMsQ0FBQyxFQUFFLElBQUksSUFBSSxDQUFDLEVBQUUsQ0FBQyxNQUFNLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQUMsSUFBSSxDQUFDLEVBQUUsR0FBRyxNQUFJLElBQUksQ0FBQyxFQUFJLENBQUM7UUFBQyxDQUFDO1FBRzVFLEdBQUcsQ0FBQSxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsSUFBSSxDQUFDLFFBQVEsQ0FBQyxNQUFNLEVBQUUsQ0FBQyxFQUFFLEVBQzVDLENBQUM7WUFDQSxrQkFBa0IsQ0FBQyxJQUFJLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyxFQUFFLEVBQUUsQ0FBQyxDQUFDO1FBQzFDLENBQUM7SUFDRixDQUFDO0lBVUQscUJBQTRCLEtBQWM7UUFFekMsTUFBTSxDQUFBLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQ2hCLENBQUM7WUFDQSxLQUFLLEdBQUc7Z0JBQ1IsQ0FBQztvQkFDQSxJQUFJLFdBQVcsR0FBRyxLQUFLLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQyxDQUFDO29CQUNyQyxFQUFFLENBQUEsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxjQUFjLENBQUMsV0FBVyxDQUFDLENBQUMsQ0FDekMsQ0FBQzt3QkFDQSxNQUFNLENBQUMsZ0JBQWEsV0FBVyx3QkFBb0IsQ0FBQztvQkFDckQsQ0FBQztvQkFDRCxJQUFJLENBQ0osQ0FBQzt3QkFDQSxNQUFNLENBQUMsYUFBYSxDQUFDLEtBQUssQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUM7b0JBQ3BELENBQUM7Z0JBQ0YsQ0FBQztZQUNELEtBQUssR0FBRztnQkFDUixDQUFDO29CQUVBLElBQUksWUFBWSxHQUFHLElBQUksQ0FBQztvQkFDeEIsSUFBSSxNQUFNLEdBQUcsS0FBSyxDQUFDLFNBQVMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLENBQUM7b0JBQzNDLEdBQUcsQ0FBQSxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsTUFBTSxDQUFDLE1BQU0sRUFBRSxDQUFDLEVBQUUsRUFDckMsQ0FBQzt3QkFDQSxFQUFFLENBQUEsQ0FBQyxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBQzs0QkFBQyxZQUFZLEdBQUcsTUFBTSxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO3dCQUFDLENBQUM7d0JBQ2pELElBQUksQ0FBQyxDQUFDOzRCQUFDLFlBQVksR0FBRyxZQUFZLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7d0JBQUMsQ0FBQztvQkFDakQsQ0FBQztvQkFDRCxFQUFFLENBQUEsQ0FBQyxZQUFZLEtBQUssU0FBUyxDQUFDLENBQzlCLENBQUM7d0JBQ0EsTUFBTSxDQUFDLGlCQUFjLEtBQUssQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDLHdCQUFvQixDQUFDO29CQUM3RCxDQUFDO29CQUNELElBQUksQ0FDSixDQUFDO3dCQUNBLE1BQU0sQ0FBQyxZQUFZLEVBQUUsQ0FBQyxRQUFRLEVBQUUsQ0FBQztvQkFDbEMsQ0FBQztnQkFDRixDQUFDO1lBQ0QsS0FBSyxHQUFHO2dCQUNSLENBQUM7b0JBRUEsSUFBSSxZQUFZLEdBQUcsSUFBSSxDQUFDO29CQUN4QixJQUFJLE1BQU0sR0FBRyxLQUFLLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsQ0FBQztvQkFDM0MsR0FBRyxDQUFBLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxNQUFNLENBQUMsTUFBTSxFQUFFLENBQUMsRUFBRSxFQUNyQyxDQUFDO3dCQUNBLEVBQUUsQ0FBQSxDQUFDLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDOzRCQUFDLFlBQVksR0FBRyxNQUFNLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7d0JBQUMsQ0FBQzt3QkFDakQsSUFBSSxDQUFDLENBQUM7NEJBQUMsWUFBWSxHQUFHLFlBQVksQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQzt3QkFBQyxDQUFDO29CQUNqRCxDQUFDO29CQUNELEVBQUUsQ0FBQSxDQUFDLFlBQVksS0FBSyxTQUFTLENBQUMsQ0FDOUIsQ0FBQzt3QkFDQSxNQUFNLENBQUMsaUJBQWMsS0FBSyxDQUFDLFNBQVMsQ0FBQyxDQUFDLENBQUMsd0JBQW9CLENBQUM7b0JBQzdELENBQUM7b0JBQ0QsSUFBSSxDQUNKLENBQUM7d0JBQ0EsTUFBTSxDQUFDLFlBQVksQ0FBQyxRQUFRLEVBQUUsQ0FBQztvQkFDaEMsQ0FBQztnQkFDRixDQUFDO1lBQ0Q7Z0JBQ0EsQ0FBQztvQkFDQSxNQUFNLENBQUMsdUNBQW9DLEtBQUssT0FBRyxDQUFDO2dCQUNyRCxDQUFDO1FBQ0YsQ0FBQztJQUNGLENBQUM7SUEzRGUsZ0JBQVcsY0EyRDFCLENBQUE7SUFPRCx1QkFBdUIsRUFBVztRQUVqQyxJQUFJLE1BQU0sR0FBRyxRQUFRLENBQUMsY0FBYyxDQUFDLEVBQUUsQ0FBQyxDQUFDO1FBQ3pDLEVBQUUsQ0FBQSxDQUFDLE1BQU0sS0FBSyxJQUFJLENBQUMsQ0FDbkIsQ0FBQztZQUNBLE9BQU8sQ0FBQyxHQUFHLENBQUMsVUFBVSxHQUFHLEVBQUUsR0FBRyxnQkFBZ0IsQ0FBQyxDQUFDO1lBQ2hELE1BQU0sQ0FBQyxJQUFJLENBQUM7UUFDYixDQUFDO1FBRUQsSUFBSSxlQUFlLEdBQUcsTUFBTSxDQUFDLFNBQVMsQ0FBQyxJQUFJLENBQVksQ0FBQztRQUN4RCxlQUFlLENBQUMsZUFBZSxDQUFDLFFBQVEsQ0FBQyxDQUFDO1FBRTFDLElBQUksSUFBSSxHQUFHLFVBQVMsT0FBaUI7WUFFcEMsR0FBRyxDQUFBLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxPQUFPLENBQUMsVUFBVSxDQUFDLE1BQU0sRUFBRSxDQUFDLEVBQUUsRUFDakQsQ0FBQztnQkFDQSxJQUFJLFFBQVEsR0FBYSxLQUFLLENBQUM7Z0JBQy9CLE1BQU0sQ0FBQSxDQUFDLE9BQU8sQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDLENBQ2xDLENBQUM7b0JBQ0EsS0FBSyxtQkFBbUI7d0JBQ3hCLENBQUM7NEJBQ0EsRUFBRSxDQUFBLENBQUMsT0FBTyxDQUFDLGFBQWEsQ0FBQyxDQUN6QixDQUFDO2dDQUNBLElBQUksVUFBVSxHQUFHLFFBQVEsQ0FBQyxhQUFhLENBQUMsTUFBTSxDQUFDLENBQUM7Z0NBQ2hELFVBQVUsQ0FBQyxTQUFTLEdBQUcsV0FBVyxDQUFDLE9BQU8sQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLENBQUM7Z0NBQ2hFLE9BQU8sQ0FBQyxhQUFhLENBQUMsWUFBWSxDQUFDLFVBQVUsRUFBRSxPQUFPLENBQUMsQ0FBQztnQ0FDeEQsUUFBUSxHQUFHLElBQUksQ0FBQzs0QkFDakIsQ0FBQzs0QkFDRCxLQUFLLENBQUM7d0JBQ1AsQ0FBQztvQkFDRCxLQUFLLHlCQUF5Qjt3QkFDOUIsQ0FBQzs0QkFDQSxJQUFJLFFBQU0sR0FBRyxXQUFXLENBQUMsT0FBTyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsQ0FBQzs0QkFDdEQsT0FBTyxDQUFDLEdBQUcsQ0FBQyxlQUFhLE9BQU8sQ0FBQyxPQUFPLDRCQUF1QixPQUFPLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQyxDQUFDLEtBQUssY0FBUSxRQUFNLE9BQUcsQ0FBQyxDQUFDOzRCQUM3RyxPQUFPLENBQUMsWUFBWSxDQUFDLEtBQUssRUFBRSxXQUFXLENBQUMsT0FBTyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDOzRCQUN0RSxRQUFRLEdBQUcsSUFBSSxDQUFDO3dCQUNqQixDQUFDO2dCQUNGLENBQUM7Z0JBSUQsRUFBRSxDQUFBLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQztvQkFBQyxLQUFLLENBQUM7Z0JBQUMsQ0FBQztZQUN4QixDQUFDO1lBQ0QsRUFBRSxDQUFBLENBQUMsT0FBTyxDQUFDLGFBQWEsQ0FBQyxDQUN6QixDQUFDO2dCQUNBLEdBQUcsQ0FBQSxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsT0FBTyxDQUFDLFFBQVEsQ0FBQyxNQUFNLEVBQUUsQ0FBQyxFQUFFLEVBQy9DLENBQUM7b0JBQ0EsSUFBSSxDQUFDLE9BQU8sQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztnQkFDM0IsQ0FBQztZQUNGLENBQUM7UUFDRixDQUFDLENBQUM7UUFDRixJQUFJLENBQUMsZUFBZSxDQUFDLENBQUM7UUFFdEIsTUFBTSxDQUFDLGVBQWUsQ0FBQztJQUN4QixDQUFDO0lBTUQscUJBQTRCLEVBQVc7UUFFdEMsSUFBSSxPQUFPLEdBQUcsUUFBUSxDQUFDLGNBQWMsQ0FBQyxXQUFXLENBQUMsQ0FBQztRQUNuRCxJQUFJLGNBQWMsR0FBRyxRQUFRLENBQUMsY0FBYyxDQUFDLGtCQUFrQixDQUFDLENBQUM7UUFJakUsSUFBSSxLQUFLLEdBQUcsY0FBYyxDQUFDLG9CQUFvQixDQUFDLEdBQUcsQ0FBQyxDQUFDO1FBQ3JELEdBQUcsQ0FBQSxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEdBQUcsS0FBSyxDQUFDLE1BQU0sR0FDL0IsQ0FBQztZQUNBLElBQUksUUFBUSxHQUFZLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUMsU0FBUyxDQUNuRCxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDLE9BQU8sQ0FBQyxHQUFHLENBQUMsR0FBRyxDQUFDLEVBQ25DLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxDQUNsQyxDQUFDO1lBQ0YsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLFNBQVMsR0FBRyxvQ0FBZ0MsUUFBUSxZQUFTLENBQUM7UUFDeEUsQ0FBQztRQUdELE9BQU8sQ0FBQyxTQUFTLElBQUksY0FBYyxDQUFDLFNBQVMsQ0FBQztRQUM5QyxPQUFPLENBQUMsU0FBUyxHQUFHLE9BQU8sQ0FBQyxZQUFZLENBQUM7UUFHekMsSUFBSSxLQUFLLEdBQUcsYUFBYSxDQUFDLEVBQUUsQ0FBQyxDQUFDO1FBQzlCLGtCQUFrQixDQUFDLEtBQUssRUFBRSxJQUFJLENBQUMsQ0FBQztRQUNoQyxhQUFhLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDckIsS0FBSyxDQUFDLFNBQVMsR0FBRyxDQUFDLENBQUM7UUFJcEIsS0FBSyxDQUFDLEVBQUUsR0FBRyxrQkFBa0IsQ0FBQztRQUM5QixjQUFjLENBQUMsYUFBYSxDQUFDLFlBQVksQ0FBQyxLQUFLLEVBQUUsY0FBYyxDQUFDLENBQUM7SUFDbEUsQ0FBQztJQS9CZSxnQkFBVyxjQStCMUIsQ0FBQTtJQU9ELHVCQUE4QixPQUFpQjtRQUU5QyxFQUFFLENBQUEsQ0FBQyxPQUFPLENBQUMsT0FBTyxJQUFJLEdBQUcsQ0FBQyxDQUMxQixDQUFDO29DQUNRLENBQUM7Z0JBRVIsTUFBTSxDQUFBLENBQUMsT0FBTyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsQ0FDbEMsQ0FBQztvQkFDQSxLQUFLLG1CQUFtQjt3QkFDeEIsQ0FBQzs0QkFDQSxPQUFPLENBQUMsZ0JBQWdCLENBQUMsT0FBTyxFQUFFO2dDQUNqQyxJQUFJLENBQUMsV0FBVyxDQUFDLE9BQU8sQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLENBQUM7NEJBQy9DLENBQUMsQ0FBQyxDQUFDOzRCQUNILEtBQUssQ0FBQzt3QkFDUCxDQUFDO29CQUNELEtBQUssb0JBQW9CO3dCQUN6QixDQUFDOzRCQUNBLE9BQU8sQ0FBQyxnQkFBZ0IsQ0FBQyxPQUFPLEVBQUUsTUFBTSxDQUFDLE9BQU8sQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQzs0QkFDdkUsS0FBSyxDQUFDO3dCQUNQLENBQUM7b0JBQ0QsS0FBSyxtQkFBbUI7d0JBQ3hCLENBQUM7NEJBQ0EsT0FBTyxDQUFDLGdCQUFnQixDQUFDLE9BQU8sRUFBRTtnQ0FDakMsSUFBSSxDQUFDLG9CQUFvQixDQUFDLE9BQU8sQ0FBQyxFQUFFLEVBQUUsV0FBVyxDQUFDLE9BQU8sQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQzs0QkFDakYsQ0FBQyxDQUFDLENBQUM7NEJBQ0gsS0FBSyxDQUFDO3dCQUNQLENBQUM7Z0JBQ0YsQ0FBQztZQUNGLENBQUM7WUF4QkQsR0FBRyxDQUFBLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxPQUFPLENBQUMsVUFBVSxDQUFDLE1BQU0sRUFBRSxDQUFDLEVBQUU7d0JBQXpDLENBQUM7YUF3QlI7UUFDRixDQUFDO1FBQ0QsRUFBRSxDQUFBLENBQUMsT0FBTyxDQUFDLGFBQWEsQ0FBQyxDQUN6QixDQUFDO1lBQ0EsR0FBRyxDQUFBLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLENBQUMsR0FBRyxPQUFPLENBQUMsUUFBUSxDQUFDLE1BQU0sRUFBRSxDQUFDLEVBQUUsRUFDL0MsQ0FBQztnQkFDQSxhQUFhLENBQUMsT0FBTyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ3BDLENBQUM7UUFDRixDQUFDO0lBQ0YsQ0FBQztJQXJDZSxrQkFBYSxnQkFxQzVCLENBQUE7SUFRRCw4QkFBcUMsRUFBVyxFQUFFLElBQWE7UUFFOUQsR0FBRyxDQUFBLENBQUMsSUFBSSxPQUFPLEdBQUcsUUFBUSxDQUFDLGNBQWMsQ0FBQyxFQUFFLENBQUMsRUFBRSxPQUFPLEVBQUUsT0FBTyxHQUFHLFFBQVEsQ0FBQyxjQUFjLENBQUMsRUFBRSxDQUFDLEVBQzdGLENBQUM7WUFDQSxFQUFFLENBQUEsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUM7Z0JBQUMsUUFBUSxDQUFDO1lBQUMsQ0FBQztZQUkxQixJQUFJLFNBQVMsR0FBYSxLQUFLLENBQUM7WUFDaEMsR0FBRyxDQUFBLENBQUMsSUFBSSxRQUFNLEdBQUcsT0FBTyxDQUFDLGFBQWEsRUFBRSxRQUFNLEVBQUUsUUFBTSxHQUFHLFFBQU0sQ0FBQyxhQUFhLEVBQzdFLENBQUM7Z0JBQ0EsRUFBRSxDQUFBLENBQUMsUUFBTSxDQUFDLEVBQUUsS0FBSyxrQkFBa0IsQ0FBQyxDQUNwQyxDQUFDO29CQUNBLFNBQVMsR0FBRyxJQUFJLENBQUM7b0JBQ2pCLEtBQUssQ0FBQztnQkFDUCxDQUFDO1lBQ0YsQ0FBQztZQUNELEVBQUUsQ0FBQSxDQUFDLFNBQVMsQ0FBQyxDQUNiLENBQUM7Z0JBQ0EsSUFBSSxXQUFXLEdBQUcsUUFBUSxDQUFDLGFBQWEsQ0FBQyxNQUFNLENBQUMsQ0FBQztnQkFDakQsV0FBVyxDQUFDLFNBQVMsR0FBRyxlQUFlLENBQUM7Z0JBQ3hDLFdBQVcsQ0FBQyxTQUFTLEdBQUcsSUFBSSxDQUFDO2dCQUM3QixrQkFBa0IsQ0FBQyxXQUFXLEVBQUUsSUFBSSxDQUFDLENBQUM7Z0JBQ3RDLGFBQWEsQ0FBQyxXQUFXLENBQUMsQ0FBQztnQkFDM0IsT0FBTyxDQUFDLFVBQVUsQ0FBQyxZQUFZLENBQUMsV0FBVyxFQUFFLE9BQU8sQ0FBQyxDQUFDO2dCQUN0RCxLQUFLLENBQUM7WUFDUCxDQUFDO1FBQ0YsQ0FBQztJQUNGLENBQUM7SUE1QmUseUJBQW9CLHVCQTRCbkMsQ0FBQTtJQU1ELHFCQUE0QixFQUFZO1FBRXZDLElBQUksT0FBTyxHQUFHLFFBQVEsQ0FBQyxjQUFjLENBQUMsV0FBVyxDQUFDLENBQUM7UUFDbkQsT0FBTyxDQUFDLE1BQU0sR0FBRyxDQUFDLEVBQUUsQ0FBQztJQUN0QixDQUFDO0lBSmUsZ0JBQVcsY0FJMUIsQ0FBQTtBQUNGLENBQUMsRUF2UmdCLElBQUksR0FBSixZQUFJLEtBQUosWUFBSSxRQXVScEIifQ==// source/script.js
+        function HideHistory() {
+            Core.ShowHistory(false);
+        }
+
+        function FunctionLink() {
+            alert("This link does something without changing the text.");
+        }
+
+        function InlineExpansionFunction() {
+            return "Inline functions get the inline tag, too. Because the inline tag is meant to tell the player nothing major will change when the link is clicked, you should be careful not to do anything crazy in an inline function.";
+        }
+
+        var InlineExpansionVariable = "variable (a string which will replace the link)";
+    </script>
+</head>
+
+<body>
+    <!-- source/text.md -->
+    <div id="Start" class="section" hidden="true">
+        <h1>The joy of tagging links!</h1>
+        <p>You may have noticed in the previous examples, links to external websites were marked with a special symbol. That symbol comes from<br/><a title="http://fontawesome.io/" target="_blank" href="http://fontawesome.io/">Font Awesome.&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></a>            (There it is again!)</p>
+        <p>You can actually customize what appears next to any link in your story by defining a link tag. These are defined in your story's <code>fractive.json</code> file under the name <code>linkTags</code>.</p>
+        <pre><code>{
+  ...
+  &quot;linkTags&quot;: {
+    &quot;external&quot;: &quot;[any HTML]&quot;,
+    &quot;inline&quot;: &quot;[any HTML]&quot;,
+    &quot;section&quot;: &quot;[any HTML]&quot;,
+    &quot;function&quot;: &quot;[any HTML]&quot;
+  }
+}
+</code></pre>
+        <p>This example story defines all of the link tags. Take a look:</p>
+        <p><a title="http://balladofthespacebard.com/" target="_blank" href="http://balladofthespacebard.com/">Some External Link&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></a><br/><a title="{$InlineExpansionVariable:inline}" href="#" data-replace-with="$InlineExpansionVariable"
+                id="_inline-0">Some Inline Link&nbsp;<i class="fa fa-exclamation" aria-hidden="true"></i></a><br/><a title="{#FunctionLink}" href="#" data-call-function="FunctionLink">Some Function Link&nbsp;<i class="fa fa-bolt" aria-hidden="true"></i></a><br/>
+            <a
+                title="{#InlineExpansionFunction:inline}" href="#" data-replace-with="#InlineExpansionFunction" id="_inline-1">Some Inline Function Link&nbsp;<i class="fa fa-exclamation" aria-hidden="true"></i></a><br/><a title="{@Start}" href="#" data-goto-section="Start">Some Section Link&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a></p>
+        <p><strong>More info</strong>:<br/><a title="{@FontAwesome}" href="#" data-goto-section="FontAwesome">Customizing tag appearance.&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a><br/><a title="{@WhenTags}" href="#" data-goto-section="WhenTags">When and why to use tags.&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a></p>
+    </div>
+    <div id="FontAwesome" class="section" hidden="true">
+        <p>We've chosen to use icons from Font Awesome for each of the link tags, but you can think bigger. For example, you might use an <code>&lt;img&gt;</code> tag to use your own icon as a tag:</p>
+        <pre><code>{
+  ...
+  &quot;linkTags&quot;: {
+    &quot;external&quot;: &quot;&lt;img src=&quot;assets/externalLink.png&quot;&gt;&lt;/img&gt;&quot;
+  }
+}
+</code></pre>
+        <p>Remember to mark quotation marks inside the link definition with a <code></code> to avoid errors.</p>
+    </div>
+    <div id="WhenTags" class="section" hidden="true">
+        <p>Tags are useful for helping the player know what to expect before they click on a link. Some players want to experience everything they can in a section before moving on to the next one, making the section tag especially useful.</p>
+        <p>However, an excess of tags can visually clutter your story. We recommend you only define the most important ones depending on the way you structure your story. For example, if you use a lot of inline links, you might want to tag only the external
+            links and section links.</p>
+    </div>
+
+    <div id="__history"></div>
+    <div id="__currentSection"></div>
+</body>
+
+</html>
+<script>
+    Core.GotoSection("Start");
+</script>

--- a/examples/tags/fractive.json
+++ b/examples/tags/fractive.json
@@ -1,0 +1,11 @@
+{
+	"title": "basic",
+	"template": "../../templates/basic.html",
+	"linkTooltips": true,
+	"linkTags": {
+		"external": "&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>",
+		"inline": "&nbsp;<i class=\"fa fa-exclamation\" aria-hidden=\"true\"></i>",
+		"section": "&nbsp;<i class=\"fa fa-arrow-right\" aria-hidden=\"true\"></i>",
+		"function": "&nbsp;<i class=\"fa fa-bolt\" aria-hidden=\"true\"></i>"
+	}
+}

--- a/examples/tags/source/script.js
+++ b/examples/tags/source/script.js
@@ -1,0 +1,16 @@
+function HideHistory()
+{
+	Core.ShowHistory(false);
+}
+
+function FunctionLink()
+{
+	alert("This link does something without changing the text.");
+}
+
+function InlineExpansionFunction()
+{
+	return "Inline functions get the inline tag, too. Because the inline tag is meant to tell the player nothing major will change when the link is clicked, you should be careful not to do anything crazy in an inline function.";
+}
+
+var InlineExpansionVariable = "variable (a string which will replace the link)";

--- a/examples/tags/source/text.md
+++ b/examples/tags/source/text.md
@@ -1,0 +1,53 @@
+{{Start}}
+
+# The joy of tagging links!
+
+You may have noticed in the previous examples, links to external websites were marked with a special symbol. That symbol comes from
+[Font Awesome.](http://fontawesome.io/) (There it is again!)
+
+You can actually customize what appears next to any link in your story by defining a link tag. These are defined in your story's `fractive.json` file under the name `linkTags`.
+
+```
+\{
+  ...
+  "linkTags": \{
+    "external": "[any HTML]",
+    "inline": "[any HTML]",
+    "section": "[any HTML]",
+    "function": "[any HTML]"
+  \}
+\}
+```
+
+This example story defines all of the link tags. Take a look:
+
+[Some External Link](http://balladofthespacebard.com/)
+[Some Inline Link]({$InlineExpansionVariable:inline})
+[Some Function Link]({#FunctionLink})
+[Some Inline Function Link]({#InlineExpansionFunction:inline})
+[Some Section Link]({@Start})
+
+**More info**:
+[Customizing tag appearance.]({@FontAwesome})
+[When and why to use tags.]({@WhenTags})
+
+{{FontAwesome}}
+
+We've chosen to use icons from Font Awesome for each of the link tags, but you can think bigger. For example, you might use an `<img>` tag to use your own icon as a tag:
+
+```
+\{
+  ...
+  "linkTags": \{
+    "external": "<img src=\\"assets/externalLink.png\\"></img>"
+  \}
+\}
+```
+
+Remember to mark quotation marks inside the link definition with a `\\` to avoid errors.
+
+{{WhenTags}}
+
+Tags are useful for helping the player know what to expect before they click on a link. Some players want to experience everything they can in a section before moving on to the next one, making the section tag especially useful.
+
+However, an excess of tags can visually clutter your story. We recommend you only define the most important ones depending on the way you structure your story. For example, if you use a lot of inline links, you might want to tag only the external links and section links.

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -58,7 +58,8 @@ export let ProjectDefaults : FractiveProject = {
 	linkTags: {
 		external: "",
 		inline: "",
-		section: ""
+		section: "",
+		function: ""
 	},
 	backButtonHTML: ""
 };

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -51,7 +51,7 @@ export let ProjectDefaults : FractiveProject = {
 	aliases: [],
 	template: "template.html",
 	output: "build",
-	outputFormat: "prettify",
+	minify: true,
 	linkTooltips: false
 };
 import * as globby from "globby";

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -691,7 +691,7 @@ export namespace Compiler
 			{
 				// Prepending _ to the id makes this :inline macro disabled by default. It gets enabled when it's moved
 				// into the __currentSection div.
-				if(!RewriteLinkNode(event.node, [{ attr: "replace-with", value: url }], GetLinkText(event.node), false, `_inline-${nextInlineID++}`)) { return false; }
+				if(!RewriteLinkNode(event.node, [{ attr: "data-replace-with", value: url }], GetLinkText(event.node), false, `_inline-${nextInlineID++}`)) { return false; }
 				break;
 			}
 			default:
@@ -700,12 +700,12 @@ export namespace Compiler
 				{
 					case "@": // Section link: navigate to the section
 					{
-						if(!RewriteLinkNode(event.node, [ { attr: "goto-section", value: url.substring(1) } ], GetLinkText(event.node), false, null)) { return false; }
+						if(!RewriteLinkNode(event.node, [ { attr: "data-goto-section", value: url.substring(1) } ], GetLinkText(event.node), false, null)) { return false; }
 						break;
 					}
 					case "#": // Function link: call the function
 					{
-						if(!RewriteLinkNode(event.node, [{ attr: "call-function", value: url.substring(1) }], GetLinkText(event.node), false, null)) { return false; }
+						if(!RewriteLinkNode(event.node, [{ attr: "data-call-function", value: url.substring(1) }], GetLinkText(event.node), false, null)) { return false; }
 						break;
 					}
 					case "$": // Variable link: behavior undefined
@@ -924,12 +924,7 @@ export namespace Compiler
 
 		for(let i = 0; i < dataAttrs.length; i++)
 		{
-			attrs += ' ';
-			// For macro links, attributes become data attributes
-			if (!hasExternalUrl) {
-				attrs += 'data-';
-			}
-			attrs += `${dataAttrs[i].attr}="${dataAttrs[i].value}"`;
+			attrs += ` ${dataAttrs[i].attr}="${dataAttrs[i].value}"`;
 		}
 
 		newNode.literal = '<a ';

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -54,7 +54,9 @@ export let ProjectDefaults : FractiveProject = {
 	template: "template.html",
 	output: "build",
 	outputFormat: "prettify",
-	linkTooltips: false
+	linkTooltips: false,
+	externalLinkHTML: "",
+	backButtonHTML: ""
 };
 import * as globby from "globby";
 
@@ -665,7 +667,7 @@ export namespace Compiler
 		// but it may still be an external link.
 		if(url[0] !== "{") {
 			if (IsExternalLink(url)) {
-				return RewriteExternalLinkNode(event.node, );
+				return RewriteExternalLinkNode(event.node);
 			}
 			else {
 				return true;
@@ -946,7 +948,7 @@ export namespace Compiler
 
 		// Remove the accidental newlines
 		newNode.literal = newNode.literal.split('\n').join('');
-		console.log(newNode.literal);
+		// console.log(newNode.literal);
 
 		node.insertBefore(newNode);
 		node.unlink();
@@ -954,13 +956,14 @@ export namespace Compiler
 		return true;
 	}
 
-	// TODO document
+	/**
+	* Rewrites an external link node so it opens in a new tab and
+	* its text is followed by the external link marker defined in externalLinkHTML.
+	*/
 	function RewriteExternalLinkNode(node)
 	{
-		console.log('rewriting an external link node');
-
 		let linkText : string = GetLinkText(node);
-		linkText += '<i class="fa fa-external-link" aria-hidden="true"></i>'; // TODO get this from fractive.json
+		linkText += project.externalLinkHTML; // TODO get this from fractive.json
 
 		return RewriteLinkNode(node, [
 			{ "attr": "target", "value": "_blank"}, // Open links in a new window

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -51,7 +51,7 @@ export let ProjectDefaults : FractiveProject = {
 	aliases: [],
 	template: "template.html",
 	output: "build",
-	minify: true,
+	outputFormat: "prettify",
 	linkTooltips: false
 };
 import * as globby from "globby";

--- a/src/ProjectSchema.d.ts
+++ b/src/ProjectSchema.d.ts
@@ -68,13 +68,17 @@ export interface FractiveProject {
      */
     external?: string;
     /**
-     * Tag for inline links.
+     * Tag for links that expand inline.
      */
     inline?: string;
     /**
      * Tag for links between sections.
      */
     section?: string;
+    /**
+     * Tag for links that execute funcitons.
+     */
+    function?: string;
     [k: string]: any;
   };
   /**

--- a/src/ProjectSchema.d.ts
+++ b/src/ProjectSchema.d.ts
@@ -59,4 +59,12 @@ export interface FractiveProject {
    * If true, show a tooltip on macro links indicating the macro destination. (Useful for dev, but you probably want to disable it for release.)
    */
   linkTooltips?: boolean;
+  /**
+   * Raw HTML that will be inserted following the text of external links in the story.
+   */
+  externalLinkHTML?: string;
+  /**
+   * Raw HTML inserted in the place where the back button is defined to be.
+   */
+  backButtonHTML?: string;
 }

--- a/src/ProjectSchema.d.ts
+++ b/src/ProjectSchema.d.ts
@@ -60,9 +60,23 @@ export interface FractiveProject {
    */
   linkTooltips?: boolean;
   /**
-   * Raw HTML that will be inserted following the text of external links in the story.
+   * Raw HTML to be inserted at the end of different Fractive link types.
    */
-  externalLinkHTML?: string;
+  linkTags?: {
+    /**
+     * Tag for external links.
+     */
+    external?: string;
+    /**
+     * Tag for inline links.
+     */
+    inline?: string;
+    /**
+     * Tag for links between sections.
+     */
+    section?: string;
+    [k: string]: any;
+  };
   /**
    * Raw HTML inserted in the place where the back button is defined to be.
    */

--- a/src/ProjectSchema.json
+++ b/src/ProjectSchema.json
@@ -47,7 +47,7 @@
 		},
 		"template": { "type": "string", "description": "The HTML template file to use for the final story output" },
 		"output": { "type": "string", "description": "The folder where the final story files will be saved" },
-		"outputFormat": { "type": "string", "description": "Options: 'minify' to minify the final story HTML (reduces file size but makes the HTML source much less human-readable), 'prettify' to prettify the final story HTML into human-readable HTML" },
+		"minify": { "type": "boolean", "description": "If true, minify the final story HTML (reduces file size but makes the HTML source much less human-readable)" },
 		"linkTooltips": { "type": "boolean", "description": "If true, show a tooltip on macro links indicating the macro destination. (Useful for dev, but you probably want to disable it for release.)" }
 	},
 	"additionalProperties": false

--- a/src/ProjectSchema.json
+++ b/src/ProjectSchema.json
@@ -48,7 +48,9 @@
 		"template": { "type": "string", "description": "The HTML template file to use for the final story output" },
 		"output": { "type": "string", "description": "The folder where the final story files will be saved" },
 		"outputFormat": { "enum": [ "prettify", "minify", "default" ], "description": "Options: 'minify' to minify the final story HTML (reduces file size but makes the HTML source much less human-readable), 'prettify' to prettify the final story HTML into human-readable HTML, 'default' for no additional processing"  },
-		"linkTooltips": { "type": "boolean", "description": "If true, show a tooltip on macro links indicating the macro destination. (Useful for dev, but you probably want to disable it for release.)" }
+		"linkTooltips": { "type": "boolean", "description": "If true, show a tooltip on macro links indicating the macro destination. (Useful for dev, but you probably want to disable it for release.)" },
+		"externalLinkHTML": { "type": "string", "description": "Raw HTML that will be inserted following the text of external links in the story." },
+		"backButtonHTML": { "type": "string", "description": "Raw HTML inserted in the place where the back button is defined to be." }
 	},
 	"additionalProperties": false
 }

--- a/src/ProjectSchema.json
+++ b/src/ProjectSchema.json
@@ -47,7 +47,7 @@
 		},
 		"template": { "type": "string", "description": "The HTML template file to use for the final story output" },
 		"output": { "type": "string", "description": "The folder where the final story files will be saved" },
-		"minify": { "type": "boolean", "description": "If true, minify the final story HTML (reduces file size but makes the HTML source much less human-readable)" },
+		"outputFormat": { "type": "string", "description": "Options: 'minify' to minify the final story HTML (reduces file size but makes the HTML source much less human-readable), 'prettify' to prettify the final story HTML into human-readable HTML" },
 		"linkTooltips": { "type": "boolean", "description": "If true, show a tooltip on macro links indicating the macro destination. (Useful for dev, but you probably want to disable it for release.)" }
 	},
 	"additionalProperties": false

--- a/src/ProjectSchema.json
+++ b/src/ProjectSchema.json
@@ -54,8 +54,9 @@
 			"description": "Raw HTML to be inserted at the end of different Fractive link types.",
 			"properties": {
 				"external": { "type": "string", "description": "Tag for external links." },
-				"inline": { "type": "string", "description": "Tag for inline links." },
-				"section": { "type": "string", "description": "Tag for links between sections." }
+				"inline": { "type": "string", "description": "Tag for links that expand inline." },
+				"section": { "type": "string", "description": "Tag for links between sections." },
+				"function": { "type": "string", "description": "Tag for links that execute funcitons." }
 			}
 		},
 		"backButtonHTML": { "type": "string", "description": "Raw HTML inserted in the place where the back button is defined to be." }

--- a/src/ProjectSchema.json
+++ b/src/ProjectSchema.json
@@ -49,7 +49,15 @@
 		"output": { "type": "string", "description": "The folder where the final story files will be saved" },
 		"outputFormat": { "enum": [ "prettify", "minify", "default" ], "description": "Options: 'minify' to minify the final story HTML (reduces file size but makes the HTML source much less human-readable), 'prettify' to prettify the final story HTML into human-readable HTML, 'default' for no additional processing"  },
 		"linkTooltips": { "type": "boolean", "description": "If true, show a tooltip on macro links indicating the macro destination. (Useful for dev, but you probably want to disable it for release.)" },
-		"externalLinkHTML": { "type": "string", "description": "Raw HTML that will be inserted following the text of external links in the story." },
+		"linkTags": {
+			"type": "object",
+			"description": "Raw HTML to be inserted at the end of different Fractive link types.",
+			"properties": {
+				"external": { "type": "string", "description": "Tag for external links." },
+				"inline": { "type": "string", "description": "Tag for inline links." },
+				"section": { "type": "string", "description": "Tag for links between sections." }
+			}
+		},
 		"backButtonHTML": { "type": "string", "description": "Raw HTML inserted in the place where the back button is defined to be." }
 	},
 	"additionalProperties": false

--- a/templates/basic.html
+++ b/templates/basic.html
@@ -55,5 +55,4 @@
 		<div id="__history"></div>
 		<div id="__currentSection"></div>
 	</body>
-	<script type="text/javascript" src="//cdn.rawgit.com/icons8/bower-webicon/v0.10.7/jquery-webicon.min.js"></script>
 </html>

--- a/templates/basic.html
+++ b/templates/basic.html
@@ -1,6 +1,7 @@
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet"></link>
 		<style>
 			#__history
 			{
@@ -54,4 +55,5 @@
 		<div id="__history"></div>
 		<div id="__currentSection"></div>
 	</body>
+	<script type="text/javascript" src="//cdn.rawgit.com/icons8/bower-webicon/v0.10.7/jquery-webicon.min.js"></script>
 </html>


### PR DESCRIPTION
Addresses issue #9 

Changes proposed by this pull request:
- `Compiler.ts` modified to rewrite external links, appending HTML defined in `fractive.json`
- The basic template includes Font Awesome
- Both examples show how to define an external link icon in `fractive.json`

Notes:
- I tried to implement this with an SVG icon using Webicon and We Love SVG, but the script tags both projects say to include in the HTML, are dead links.
- Maybe `fractive.json` isn't a good place to be defining raw HTML stuff. Or maybe it is, but those things should be specially named aliases.
- I've laid the groundwork for `fractive.json` to also define raw HTML for a back button (#36). If this approach is accepted I can carry on implementing that.

@invicticide to review
