### PR TITLE
Aliases can be defined as regexes and use regex replacement expressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -698,6 +698,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
       "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0="
+    },
+    "xregexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "js-beautify": "^1.7.4",
     "json-override": "^0.2.0",
     "json-schema-to-typescript": "^5.1.0",
-    "source-map-support": "^0.5.0"
+    "source-map-support": "^0.5.0",
+    "xregexp": "^4.0.0"
   },
   "scripts": {
     "build": "node build/Build.js",

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -1194,9 +1194,12 @@ export namespace Compiler
 							else if (alias.hasOwnProperty('regex'))
 							{
 								regexp = XRegExp(alias.regex);
+                                console.log(`Checking macro ${macroName} against regex ${alias.regex}`);
 								regexpToReplace = XRegExp('{' + (bIsEnd ? '/' : '') + alias.regex + '}');
+
 								if (regexp.exec(macroName)) {
 									regexpReplacement = (bIsEnd ? alias.end : alias.replaceWith);
+                                    break;
 								}
 							}
 						}
@@ -1208,6 +1211,7 @@ export namespace Compiler
 						}
 						else if (regexpReplacement)
 						{
+                            console.log(`Replacing macro ${macroName} with ${regexpReplacement}`);
 							replacement = XRegExp.replace(regexpToReplace, regexpToReplace, regexpReplacement);
 							markdown = XRegExp.replace(markdown, regexpToReplace, regexpReplacement, 'all');
 							i += replacement.length - 1;

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -1194,10 +1194,17 @@ export namespace Compiler
 							else if (alias.hasOwnProperty('regex'))
 							{
 								regexp = XRegExp(alias.regex);
-                                console.log(`Checking macro ${macroName} against regex ${alias.regex}`);
+                                if (alias.debug)
+                                {
+                                    console.log(`Checking macro ${macroName} against regex ${alias.regex}`);
+                                }
 								regexpToReplace = XRegExp('{' + (bIsEnd ? '/' : '') + alias.regex + '}');
 
 								if (regexp.exec(macroName)) {
+                                    if (alias.debug)
+                                    {
+                                        console.log(`Replacing macro ${macroName} with ${regexpReplacement}`);
+                                    }
 									regexpReplacement = (bIsEnd ? alias.end : alias.replaceWith);
                                     break;
 								}
@@ -1211,7 +1218,6 @@ export namespace Compiler
 						}
 						else if (regexpReplacement)
 						{
-                            console.log(`Replacing macro ${macroName} with ${regexpReplacement}`);
 							replacement = XRegExp.replace(regexpToReplace, regexpToReplace, regexpReplacement);
 							markdown = XRegExp.replace(markdown, regexpToReplace, regexpReplacement, 'all');
 							i += replacement.length - 1;

--- a/src/ProjectSchema.json
+++ b/src/ProjectSchema.json
@@ -38,6 +38,7 @@
 				"type": "object",
 				"properties": {
 					"alias": { "type": "string" },
+					"regex": { "type": "string" },
 					"replaceWith": { "type": "string" },
 					"end": { "type": "string" }
 				}

--- a/src/ProjectSchema.json
+++ b/src/ProjectSchema.json
@@ -40,7 +40,8 @@
 					"alias": { "type": "string" },
 					"regex": { "type": "string" },
 					"replaceWith": { "type": "string" },
-					"end": { "type": "string" }
+					"end": { "type": "string" },
+                    "debug": { "type": "boolean" }
 				}
 			},
 			"uniqueItems": true,


### PR DESCRIPTION
I wanted to be able to define a single alias that would handle a range of expressions (essentially, giving aliases internal parameters that could be included in the replacement). So I made that a thing.

Changes proposed by this pull request:
- XRegExp added as a dependency to allow for named groups (a must, IMO)
- Aliases can define 'regex' instead of 'alias' to use regex matching
- 'replaceWith' and 'end' can be defined as XRegExp replacement expressions, which allow including match groups from 'regex' *in* the replaced text. This is awesome.

@invicticide to review
