### PR TITLE
Fix import of XRegExp

### DIFF
--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -28,7 +28,7 @@ import * as path from "path";
 import * as util from "util";
 
 // XRegExp
-import * as XRegExp from "XRegExp";
+import * as XRegExp from "xregexp";
 
 // Set up the Markdown parser and renderer
 import * as commonmark from "commonmark";


### PR DESCRIPTION
Addresses issue #86 

Changes proposed by this pull request:
- Change 'XRegExp' import to 'xregexp', as advised by the [XRegExp docs](http://xregexp.com/)

@invicticide to review
