### PR TITLE
Format fix

### DIFF
--- a/build/Build.js
+++ b/build/Build.js
@@ -104,34 +104,24 @@ function BuildExamples()
 {
 	console.log("Building examples...");
 
-  // List every file/directory in the examples folder to find story folders
 	let examples = fs.readdirSync("examples", "utf8");
-  // Construct full directory paths for stories and remove non-story
-  // files/directories from the list so progress reporting is valid
 	for(let i = 0; i < examples.length; i++)
 	{
 		// Ignore dotfiles (.git, .DS_Store, etc.)
-		if(examples[i][0] === ".") { examples.splice(i--, 1); continue; }
-    // Convert directories to be relative to fractive root
-    examples[i] = `examples/${examples[i]}`;
-    // Ignore directories without a fractive.json
-    if (!fs.existsSync(`${examples[i]}/fractive.json`)) { examples.splice(i--, 1); continue; }
+		if(examples[i][0] === ".") { examples.splice(i--, 1); }
 	}
-  // Attempt to build every folder with a story in it
 	for(let i = 0; i < examples.length; i++)
 	{
 		console.log(`  ${examples[i]} (${i + 1}/${examples.length})`);
 
-    // Build the directory in a child process and retrieve the result
-		let cmd = `node lib/CLI.js compile ${examples[i]} ${process.argv.slice(2).join(" ")}`;
+		let cmd = `node lib/CLI.js compile examples/${examples[i]} ${process.argv.slice(2).join(" ")}`;
 		let result = cp.spawnSync(cmd, [], { env : process.env, shell : true });
-    // Print any build output
 		if(result.stdout !== null)
 		{
 			let s = result.stdout.toString();
 			if(s.length > 0) { console.log(`${result.stdout.toString()}`); }
 		}		
-    // If an example build failed, interrupt the Fractive build.
+
 		if(result.status !== 0)
 		{
 			if(result.stderr !== null) { console.error(`\n${result.stderr.toString()}`); }

--- a/templates/basic.html
+++ b/templates/basic.html
@@ -97,6 +97,7 @@
 			h1 {
 				font-family: Arial, Helvetica, sans-serif;
 				font-size: 56pt;
+				text-transform: none;
 				margin-top: 28pt;
 				margin-bottom: -4pt;
 				line-height: 0.9em;
@@ -104,6 +105,7 @@
 			h2 {
 				font-family: Arial, Helvetica, sans-serif;
 				font-size: 38pt;
+        text-transform: none;
 				margin-top: 19pt;
 				margin-bottom: -12pt;
 			}
@@ -118,6 +120,7 @@
 				background-color: #FAFAFA;
 			}
 			p {
+        text-transform: none;
 				font-family: Arial, Helvetica, sans-serif;
 				font-size: 16pt;
 				line-height: 1.5em;

--- a/templates/basic.html
+++ b/templates/basic.html
@@ -97,7 +97,6 @@
 			h1 {
 				font-family: Arial, Helvetica, sans-serif;
 				font-size: 56pt;
-				text-transform: none;
 				margin-top: 28pt;
 				margin-bottom: -4pt;
 				line-height: 0.9em;
@@ -105,7 +104,6 @@
 			h2 {
 				font-family: Arial, Helvetica, sans-serif;
 				font-size: 38pt;
-        text-transform: none;
 				margin-top: 19pt;
 				margin-bottom: -12pt;
 			}
@@ -120,7 +118,6 @@
 				background-color: #FAFAFA;
 			}
 			p {
-        text-transform: none;
 				font-family: Arial, Helvetica, sans-serif;
 				font-size: 16pt;
 				line-height: 1.5em;


### PR DESCRIPTION
Addresses issue #91 (In a way that's way more clean than I originally outlined)

Changes proposed by this pull request:
- Every text style defined in the stylesheet declares `text-transform: none;` to counterract the `text-transform: uppercase;` in `h3` of the default template which can cause unwanted capitalization of inline link contents.

@invicticide to review
